### PR TITLE
Add authentication test

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,3 +6,13 @@
 2. `.env.example` kopieren zu `.env`
 3. `python -m playwright install`
 4. `gunicorn -k uvicorn.workers.UvicornWorker main:app --bind 0.0.0.0:8000 --workers 4`
+
+## Tests
+
+Nach Installation der Abhängigkeiten können die Backend-Tests mit `pytest` ausgeführt werden:
+
+```bash
+pytest
+```
+
+Die Tests nutzen FastAPIs `TestClient` und benötigen keine weitere Konfiguration.

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,30 @@
+import os
+import importlib
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+
+def test_register_and_login(tmp_path):
+    # Use a temporary database for isolation
+    os.environ['DB_PATH'] = str(tmp_path / 'test.db')
+    os.environ['SECRET_KEY'] = 'testsecret'
+
+    # Ensure the backend package can be imported when running from repo root
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    # Import the app after setting env vars so init_db uses the temp DB
+    import backend.main as main
+    importlib.reload(main)
+
+    client = TestClient(main.app)
+
+    # Register a new user
+    register_resp = client.post('/register', json={'username': 'testuser', 'password': 'pw'})
+    assert register_resp.status_code == 200
+
+    # Request a token using the same credentials
+    token_resp = client.post('/token', json={'username': 'testuser', 'password': 'pw'})
+    assert token_resp.status_code == 200
+    data = token_resp.json()
+    assert data.get('access_token')


### PR DESCRIPTION
## Summary
- add pytest for register/login flow using FastAPI TestClient
- document test execution in backend README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627da108ec8329a07315d8c54ea712