### PR TITLE
Add global .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info/
+dist/
+build/
+
+# Node artifacts
+node_modules/
+
+# Environment files
+.env
+.env.*
+
+# Logs and temp files
+*.log
+*.tmp
+*.cache
+
+# Editor directories
+.vscode/
+.idea/
+
+# OS files
+.DS_Store


### PR DESCRIPTION
## Summary
- add a repository root `.gitignore` to ignore temp files, Python cache, Node modules, editor folders, and environment files

## Testing
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'httpx'`)*
- `npm test` in `frontend` *(fails: missing npm script)*

------
https://chatgpt.com/codex/tasks/task_e_6862e1da02908329994f8c98438aabb0