### PR TITLE
Enhance Prime Gaming helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,24 @@ docker-compose up
 ```
 
 The backend will be available on port `8000` and the frontend on `5173`. For more information about each component, check their individual READMEs.
+
+## Claim Script
+
+The repository now contains a helper script to automatically claim the currently
+free games from Prime Gaming. The script lives in
+`backend/claim_prime_gaming.py` and uses Playwright similar to the approach from
+[free-games-claimer](https://github.com/vogler/free-games-claimer).
+
+Set your Amazon credentials via environment variables before running:
+
+```bash
+export AMZ_EMAIL="you@example.com"
+export AMZ_PASSWORD="mypassword"
+export AMZ_OTPKEY="BASE32SECRET"  # optional
+python backend/claim_prime_gaming.py
+```
+
+The script logs in, claims available games and prints the titles of the claimed
+offers. Claimed titles are stored in `data/prime-gaming.json`. Set `AMZ_NOTIFY`
+to an [Apprise](https://github.com/caronc/apprise) URL to receive a notification
+after claiming.

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,6 +7,15 @@
 3. `python -m playwright install`
 4. `gunicorn -k uvicorn.workers.UvicornWorker main:app --bind 0.0.0.0:8000 --workers 4`
 
+Zusätzlich steht mit `claim_prime_gaming.py` ein kleines Skript zur Verfügung,
+das wie im Projekt [free-games-claimer](https://github.com/vogler/free-games-claimer)
+automatisch die aktuell kostenlosen Prime-Gaming-Spiele einlöst. Vor dem
+Aufruf müssen die Umgebungsvariablen `AMZ_EMAIL` und `AMZ_PASSWORD` gesetzt
+werden. Optional kann `AMZ_OTPKEY` für Zwei-Faktor-Logins genutzt werden.
+Die Titel werden in `data/prime-gaming.json` gespeichert. Über `AMZ_NOTIFY`
+kann eine [Apprise](https://github.com/caronc/apprise) URL gesetzt werden,
+um nach erfolgreichen Claims Benachrichtigungen zu erhalten.
+
 ## Tests
 
 Nach Installation der Abhängigkeiten können die Backend-Tests mit `pytest` ausgeführt werden:

--- a/backend/claim_prime_gaming.py
+++ b/backend/claim_prime_gaming.py
@@ -1,0 +1,117 @@
+import os
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pyotp
+from playwright.sync_api import sync_playwright
+from apprise import Apprise
+
+URL_HOME = "https://gaming.amazon.com/home"
+LOG_FILE = Path(os.getenv("AMZ_LOGFILE", "data/prime-gaming.json"))
+
+
+def login(page, email, password, otp_key=None):
+    page.goto(URL_HOME)
+    page.wait_for_load_state("networkidle")
+    # Accept cookies if banner present
+    try:
+        page.click('[aria-label="Cookies usage disclaimer banner"] button:has-text("Accept")', timeout=5000)
+    except Exception:
+        pass
+    if page.locator('button:has-text("Sign in")').count():
+        page.click('button:has-text("Sign in")')
+        page.fill('[name=email]', email)
+        page.click('input[type="submit"]')
+        page.fill('[name=password]', password)
+        page.click('input[type="submit"]')
+        if otp_key:
+            try:
+                page.wait_for_selector('input[name=otpCode]', timeout=10000)
+                otp = pyotp.TOTP(otp_key).now()
+                page.fill('input[name=otpCode]', otp)
+                page.click('input[type="submit"]')
+            except Exception:
+                pass
+        page.wait_for_url('**/home?signedIn=true', timeout=60000)
+
+
+def claim_games(page):
+    claimed = []
+    page.click('button[data-type="Game"]').catch(lambda _: None)
+    cards = page.locator('div[data-a-target="offer-list-FGWP_FULL"] div:has-text("Claim")')
+    count = cards.count()
+    for i in range(count):
+        card = cards.nth(i)
+        title = card.locator('.item-card-details__body__primary').inner_text()
+        card.click()
+        page.wait_for_load_state('networkidle')
+        try:
+            page.click('[data-a-target="buy-box"] .tw-button:has-text("Get game")', timeout=5000)
+        except Exception:
+            try:
+                page.click('[data-a-target="buy-box"] .tw-button:has-text("Claim")', timeout=5000)
+            except Exception:
+                pass
+        claimed.append(title)
+        page.goto(URL_HOME)
+        page.wait_for_load_state('networkidle')
+        page.click('button[data-type="Game"]').catch(lambda _: None)
+    return claimed
+
+
+def log_claims(user, titles):
+    if not titles:
+        return
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if LOG_FILE.exists():
+        try:
+            data = json.loads(LOG_FILE.read_text())
+        except Exception:
+            data = {}
+    else:
+        data = {}
+    user_data = data.setdefault(user, {})
+    now = datetime.utcnow().isoformat()
+    for title in titles:
+        user_data[title] = {"title": title, "time": now}
+    LOG_FILE.write_text(json.dumps(data, indent=2))
+
+
+def notify_claims(titles):
+    notify_url = os.getenv("AMZ_NOTIFY")
+    if not notify_url or not titles:
+        return
+    apobj = Apprise()
+    apobj.add(notify_url)
+    msg = "Claimed:\n" + "\n".join(f"- {t}" for t in titles)
+    apobj.notify(body=msg, title="Prime Gaming")
+
+
+def main():
+    email = os.getenv("AMZ_EMAIL")
+    password = os.getenv("AMZ_PASSWORD")
+    otp_key = os.getenv("AMZ_OTPKEY")
+    headless = os.getenv("HEADLESS", "1") != "0"
+    if not email or not password:
+        print("Missing AMZ_EMAIL/AMZ_PASSWORD env variables")
+        return
+    with sync_playwright() as p:
+        browser = p.firefox.launch(headless=headless)
+        context = browser.new_context()
+        page = context.new_page()
+        login(page, email, password, otp_key)
+        claimed = claim_games(page)
+        if claimed:
+            print("Claimed:")
+            for t in claimed:
+                print("-", t)
+            log_claims(email, claimed)
+            notify_claims(claimed)
+        else:
+            print("No claimable games found")
+        browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ playwright
 sqlite-utils
 python-dotenv
 httpx==0.24.1
+pyotp
+apprise

--- a/backend/tests/test_claim_script.py
+++ b/backend/tests/test_claim_script.py
@@ -1,0 +1,6 @@
+import importlib
+
+def test_module_loads():
+    mod = importlib.import_module('backend.claim_prime_gaming')
+    assert hasattr(mod, 'login')
+    assert hasattr(mod, 'claim_games')

--- a/backend/tests/test_log_file.py
+++ b/backend/tests/test_log_file.py
@@ -1,0 +1,13 @@
+import json
+import importlib
+from pathlib import Path
+
+
+def test_log_claims(tmp_path, monkeypatch):
+    monkeypatch.setenv('AMZ_LOGFILE', str(tmp_path/'log.json'))
+    mod = importlib.reload(importlib.import_module('backend.claim_prime_gaming'))
+    mod.log_claims('user@example.com', ['Game A'])
+    data = json.loads(Path(tmp_path/'log.json').read_text())
+    assert 'user@example.com' in data
+    assert 'Game A' in data['user@example.com']
+


### PR DESCRIPTION
## Summary
- add `apprise` dependency for notifications
- log claimed games to `data/prime-gaming.json`
- optionally send notifications after claiming
- document new environment variables
- test claim logging

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e6d138508329bd8fdccb0840ad7a